### PR TITLE
ci: restore previous auto-commit flow and standardize commit identity config

### DIFF
--- a/.github/workflows/update-solo-formula.yml
+++ b/.github/workflows/update-solo-formula.yml
@@ -50,57 +50,15 @@ jobs:
 
       - name: Commit Version Changes
         id: git-commit
-        env:
-          VERSION: ${{ inputs.version || github.event.inputs.version }}
-          GPG_KEYID: ${{ steps.gpg_key.outputs.keyid }}
-          GIT_AUTHOR_NAME: ${{ steps.gpg_key.outputs.name }}
-          GIT_AUTHOR_EMAIL: ${{ steps.gpg_key.outputs.email }}
-          GIT_COMMITTER_NAME: ${{ steps.gpg_key.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.gpg_key.outputs.email }}
-        run: |
-          set -euo pipefail
-          BRANCH="chore/bump-solo-homebrew-${VERSION}"
-          git checkout -b "${BRANCH}"
-
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "committed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git add -A
-          git commit --signoff --gpg-sign="${GPG_KEYID}" -m "chore: bump solo Homebrew formula to ${VERSION}"
-          git push --set-upstream origin "${BRANCH}"
-
-          echo "committed=true" >> "$GITHUB_OUTPUT"
-          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Verify Commit Signature On GitHub
-        if: steps.git-commit.outputs.committed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          COMMIT_SHA: ${{ steps.git-commit.outputs.commit_sha }}
-        run: |
-          set -euo pipefail
-          VERIFIED=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}" --jq '.commit.verification.verified')
-          REASON=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}" --jq '.commit.verification.reason')
-
-          if [ "${VERIFIED}" = "true" ]; then
-            echo "Commit ${COMMIT_SHA} is verified on GitHub."
-            exit 0
-          fi
-
-          # GitHub can report no_user for valid bot/service signatures that are
-          # not linked to a GitHub user account. Treat this as non-blocking.
-          if [ "${REASON}" = "no_user" ]; then
-            echo "::warning::Commit ${COMMIT_SHA} signature is not linked to a GitHub user (reason: ${REASON}); continuing."
-            exit 0
-          fi
-
-          if [ "${VERIFIED}" != "true" ]; then
-            echo "Commit ${COMMIT_SHA} is not verified on GitHub (reason: ${REASON})."
-            exit 1
-          fi
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        with:
+          author_name: ${{ steps.gpg_key.outputs.name }}
+          author_email: ${{ steps.gpg_key.outputs.email }}
+          committer_name: ${{ steps.gpg_key.outputs.name }}
+          committer_email: ${{ steps.gpg_key.outputs.email }}
+          commit: --signoff --gpg-sign
+          message: "chore: bump solo Homebrew formula to ${{ inputs.version || github.event.inputs.version }}"
+          new_branch: chore/bump-solo-homebrew-${{ inputs.version || github.event.inputs.version }}
 
       - name: Create pull request
         if: steps.git-commit.outputs.committed == 'true'
@@ -112,6 +70,6 @@ jobs:
           Requested version: \`${VERSION}\`."
           gh pr create \
             --base main \
-            --head "${{ steps.git-commit.outputs.branch }}" \
+            --head "chore/bump-solo-homebrew-${VERSION}" \
             --title "chore: bump solo Homebrew formula to ${VERSION}" \
             --body "${PR_BODY}"

--- a/.github/workflows/update-solo-formula.yml
+++ b/.github/workflows/update-solo-formula.yml
@@ -52,10 +52,10 @@ jobs:
         id: git-commit
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
-          author_name: ${{ vars.GIT_USER_NAME || secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
-          author_email: ${{ vars.GIT_USER_EMAIL || secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
-          committer_name: ${{ vars.GIT_USER_NAME || secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
-          committer_email: ${{ vars.GIT_USER_EMAIL || secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
+          author_name: ${{ secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
+          author_email: ${{ secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
+          committer_name: ${{ secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
+          committer_email: ${{ secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
           commit: --signoff --gpg-sign
           message: "chore: bump solo Homebrew formula to ${{ inputs.version || github.event.inputs.version }}"
           new_branch: chore/bump-solo-homebrew-${{ inputs.version || github.event.inputs.version }}

--- a/.github/workflows/update-solo-formula.yml
+++ b/.github/workflows/update-solo-formula.yml
@@ -85,12 +85,22 @@ jobs:
           VERIFIED=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}" --jq '.commit.verification.verified')
           REASON=$(gh api "repos/${{ github.repository }}/commits/${COMMIT_SHA}" --jq '.commit.verification.reason')
 
+          if [ "${VERIFIED}" = "true" ]; then
+            echo "Commit ${COMMIT_SHA} is verified on GitHub."
+            exit 0
+          fi
+
+          # GitHub can report no_user for valid bot/service signatures that are
+          # not linked to a GitHub user account. Treat this as non-blocking.
+          if [ "${REASON}" = "no_user" ]; then
+            echo "::warning::Commit ${COMMIT_SHA} signature is not linked to a GitHub user (reason: ${REASON}); continuing."
+            exit 0
+          fi
+
           if [ "${VERIFIED}" != "true" ]; then
             echo "Commit ${COMMIT_SHA} is not verified on GitHub (reason: ${REASON})."
             exit 1
           fi
-
-          echo "Commit ${COMMIT_SHA} is verified on GitHub."
 
       - name: Create pull request
         if: steps.git-commit.outputs.committed == 'true'

--- a/.github/workflows/update-solo-formula.yml
+++ b/.github/workflows/update-solo-formula.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Commit Version Changes
         id: git-commit
-        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+        uses: step-security/add-and-commit@v9
         with:
           author_name: ${{ secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
           author_email: ${{ secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}

--- a/.github/workflows/update-solo-formula.yml
+++ b/.github/workflows/update-solo-formula.yml
@@ -53,9 +53,9 @@ jobs:
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           author_name: ${{ steps.gpg_key.outputs.name }}
-          author_email: ${{ steps.gpg_key.outputs.email }}
+          author_email: eng-automation@hashgraph.com
           committer_name: ${{ steps.gpg_key.outputs.name }}
-          committer_email: ${{ steps.gpg_key.outputs.email }}
+          committer_email: eng-automation@hashgraph.com
           commit: --signoff --gpg-sign
           message: "chore: bump solo Homebrew formula to ${{ inputs.version || github.event.inputs.version }}"
           new_branch: chore/bump-solo-homebrew-${{ inputs.version || github.event.inputs.version }}

--- a/.github/workflows/update-solo-formula.yml
+++ b/.github/workflows/update-solo-formula.yml
@@ -52,10 +52,10 @@ jobs:
         id: git-commit
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
-          author_name: ${{ steps.gpg_key.outputs.name }}
-          author_email: eng-automation@hashgraph.com
-          committer_name: ${{ steps.gpg_key.outputs.name }}
-          committer_email: eng-automation@hashgraph.com
+          author_name: ${{ vars.GIT_USER_NAME || secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
+          author_email: ${{ vars.GIT_USER_EMAIL || secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
+          committer_name: ${{ vars.GIT_USER_NAME || secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
+          committer_email: ${{ vars.GIT_USER_EMAIL || secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
           commit: --signoff --gpg-sign
           message: "chore: bump solo Homebrew formula to ${{ inputs.version || github.event.inputs.version }}"
           new_branch: chore/bump-solo-homebrew-${{ inputs.version || github.event.inputs.version }}


### PR DESCRIPTION
## Summary
- restore the previous working workflow pattern for homebrew formula updates:
  - `step-security/harden-runner`
  - `step-security/ghaction-import-gpg`
  - `EndBug/add-and-commit` for commit + push
  - `gh pr create` for PR creation
- remove custom manual commit/push and custom GitHub verification bypass logic
- standardize commit identity configuration to:
  - `secrets.GIT_USER_NAME || steps.gpg_key.outputs.name`
  - `secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email`
  - (no `vars.*` usage)

## Why
- aligns with reviewer guidance to use the existing proven actions flow
- avoids custom verification bypass behavior
- keeps identity configurable via secrets while retaining safe fallback from imported GPG key metadata

### Test 
Auto create PR sucessfully
https://github.com/hiero-ledger/homebrew-tools/pull/52
