### PR TITLE
ci: use vars.GIT_USER_* for homebrew auto-commit identity

### DIFF
--- a/.github/workflows/update-solo-formula.yml
+++ b/.github/workflows/update-solo-formula.yml
@@ -52,10 +52,10 @@ jobs:
         id: git-commit
         uses: step-security/add-and-commit@c02fc48d1a9e30e6955e3c170b06c51ceb2d26df # v9.1.5
         with:
-          author_name: ${{ secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
-          author_email: ${{ secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
-          committer_name: ${{ secrets.GIT_USER_NAME || steps.gpg_key.outputs.name }}
-          committer_email: ${{ secrets.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
+          author_name: ${{ vars.GIT_USER_NAME || steps.gpg_key.outputs.name }}
+          author_email: ${{ vars.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
+          committer_name: ${{ vars.GIT_USER_NAME || steps.gpg_key.outputs.name }}
+          committer_email: ${{ vars.GIT_USER_EMAIL || steps.gpg_key.outputs.email }}
           commit: --signoff --gpg-sign
           message: "chore: bump solo Homebrew formula to ${{ inputs.version || github.event.inputs.version }}"
           new_branch: chore/bump-solo-homebrew-${{ inputs.version || github.event.inputs.version }}


### PR DESCRIPTION
## Summary
- switch workflow commit identity from `secrets.GIT_USER_NAME` / `secrets.GIT_USER_EMAIL` to `vars.GIT_USER_NAME` / `vars.GIT_USER_EMAIL`
- keep fallback to `steps.gpg_key.outputs.*` unchanged

## Why
- repository is configured with Actions Variables for `GIT_USER_*`
- using `vars.*` avoids silent fallback to gpg email when secret values are not provided

## Related
- addresses diagnostics in #58