### PR TITLE
chore: add MAINTAINERS.md to outline maintainer roles

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,31 @@
+# Maintainers
+
+The general handling of Maintainer rights and all groups in this GitHub org is done in the https://github.com/hiero-ledger/governance repository.
+
+## Maintainer Scopes, GitHub Roles and GitHub Teams
+
+Maintainers are assigned the following scopes in this repository:
+
+|        Scope        |            Definition             | GitHub Role |            GitHub Team             |
+|---------------------|-----------------------------------|-------------|------------------------------------|
+| project-maintainers | The Maintainers of the project    | Maintain    | `hiero-homebrew-tools-maintainers` |
+| tsc                 | The Hiero TSC                     | Maintain    | `tsc`                              |
+| github-maintainers  | The Maintainers of the github org | Maintain    | `github-maintainers`               |
+
+## Active Maintainers
+
+|         Name          |     GitHub ID      | Scope | LFID | Discord ID | Email | Company Affiliation |
+|-----------------------|--------------------|-------|------|------------|-------|---------------------|
+| Nathan Klick          | nathanklick        |       |      |            |       | Hashgraph           |
+| Roger Barker          | rbarker-dev        |       |      |            |       | Hashgraph           |
+| Andrew Brandt         | andrewb1269        |       |      |            |       | Hashgraph           |
+
+## Emeritus Maintainers
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|------|-----------|-------|------|------------|-------|---------------------|
+|      |           |       |      |            |       |                     |
+
+## The Duties of a Maintainer
+
+Maintainers are expected to perform duties in alignment with **[Hiero-Ledger's defined maintainer guidelines](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md#about-users-and-maintainers).**

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,6 +19,7 @@ Maintainers are assigned the following scopes in this repository:
 | Nathan Klick          | nathanklick        |       |      |            |       | Hashgraph           |
 | Roger Barker          | rbarker-dev        |       |      |            |       | Hashgraph           |
 | Andrew Brandt         | andrewb1269        |       |      |            |       | Hashgraph           |
+| Jeromy Cannon         | jeromy-cannon      |       |      |            |       | Hashgraph           |
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
Document the roles, scopes, and responsibilities of maintainers in the project.
