### PR TITLE
fix: delete SOLO_HOME on install

### DIFF
--- a/Formula/solo.template.rb
+++ b/Formula/solo.template.rb
@@ -289,6 +289,10 @@ class Solo < Formula
     end
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
+    # Step 4a: Reset the Solo home directory so stale config, logs, keys, and other per-deployment
+    # state do not carry over between installs.
+    reset_solo_home_directory
+
     # Step 4b: Warm default Solo images to reduce first-run setup time.
     pull_default_cache_images unless ENV.key?("HOMEBREW_NO_SOLO_CACHE")
   end
@@ -334,6 +338,16 @@ class Solo < Formula
   end
 
   private
+
+  def reset_solo_home_directory
+    require "fileutils"
+    solo_home = ENV["SOLO_HOME"]
+    solo_home = File.join(ENV["HOME"] || Dir.home, ".solo") if solo_home.nil? || solo_home.empty?
+    FileUtils.rm_rf(solo_home)
+    ohai "Reset Solo home directory: #{solo_home}"
+  rescue StandardError => e
+    opoo "Could not reset Solo home directory (#{e.message}). Continuing install."
+  end
 
   def pull_default_cache_images
     solo_bin = libexec/"bin/solo"


### PR DESCRIPTION
**Description**:
This PR adds a new step to the installation formula, which deletes any existing SOLO_HOME directory. This ensures there are no leftover artifacts from previous installations. 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
