### PR TITLE
feat: warn in caveats that Homebrew support is being removed

### DIFF
--- a/Formula/solo.rb
+++ b/Formula/solo.rb
@@ -331,6 +331,12 @@ class Solo < Formula
 
   def caveats
     <<~EOS
+      WARNING: Homebrew support for Solo is being removed.
+      This formula stops being updated after August 31, 2026.
+      Switch to npm to keep receiving updates:
+        brew uninstall solo && npm install -g @hiero-ledger/solo
+      Upgrade guide: https://solo.hiero.org/docs/simple-solo-setup/upgrading-solo/
+
       If `solo` still resolves to an old path after install, your shell may be using a cached command path.
       Refresh your shell command cache:
         hash -r

--- a/Formula/solo.template.rb
+++ b/Formula/solo.template.rb
@@ -331,6 +331,12 @@ class Solo < Formula
 
   def caveats
     <<~EOS
+      WARNING: Homebrew support for Solo is being removed.
+      This formula stops being updated after August 31, 2026.
+      Switch to npm to keep receiving updates:
+        brew uninstall solo && npm install -g @hiero-ledger/solo
+      Upgrade guide: https://solo.hiero.org/docs/simple-solo-setup/upgrading-solo/
+
       If `solo` still resolves to an old path after install, your shell may be using a cached command path.
       Refresh your shell command cache:
         hash -r


### PR DESCRIPTION
## Description

Adds the Homebrew deprecation notice to the `caveats` block of the `solo` formula (and `solo.template.rb`, so regenerated formulas keep it). Homebrew prints caveats on every `brew install` / `brew upgrade` and in `brew info solo`, so users see the notice at exactly the install/upgrade moments hiero-ledger/solo#5365 asks about.

The wording (end-of-updates date, npm migration command, upgrade-guide link) matches the runtime banner in hiero-ledger/solo#5382 and the README notice from hiero-ledger/solo#5383.

## Related Issues

- hiero-ledger/solo#5364
- hiero-ledger/solo#5365
- Follow-up to the review discussion on hiero-ledger/solo#5382